### PR TITLE
Add option to use curl in jsonrpc Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ $client->request('method-one')
     ->send();
 ```
 
+### Client configuration
+
+Client can be configured with additional options:
+ - `timeout` in seconds, connection timeout for `file_get_contents` calls.
+
+```php
+$client = new trifs\jsonrpc\Client(
+    'http://example.com',
+    ['timeout' => 5, ]
+);
+```
+
+There is also the option of swapping `file_get_contents` call with an implementation that uses `curl`:
+```php
+$client->setTransporter(new trifs\jsonrpc\Client\Transporter\CurlTransporter());
+```
+The option might be useful if php.ini configuration `allow_url_fopen` is set to `Off`, which disables `file_get_contents` for remote URLs.
+
+
 ### Server
 
 ```php

--- a/src/trifs/jsonrpc/Client/Transporter/CurlTransporter.php
+++ b/src/trifs/jsonrpc/Client/Transporter/CurlTransporter.php
@@ -1,0 +1,66 @@
+<?php
+namespace trifs\jsonrpc\Client\Transporter;
+
+class CurlTransporter implements TransporterInterface
+{
+    const HTTP_OK         = 200;
+    const HTTP_NO_CONTENT = 204;
+
+    /**
+     * Transports payload to uri using curl.
+     *
+     * @param  string $uri
+     * @param  string $payload
+     * @param  array  $params
+     * @return string $response
+     * @throws Exception if request is invalid
+     */
+    public function request($uri, $payload, array $params)
+    {
+        // set timeout in seconds or use default timeout as fallback
+        if (!isset($params['timeout'])) {
+            throw new Execption("Missing 'timeout' param");
+        }
+
+        $timeout = (float) $params['timeout'];
+
+        // init curl options
+        $options = [
+                CURLOPT_RETURNTRANSFER    => true,
+                CURLOPT_URL               => $uri,
+                CURLOPT_POST              => true,
+                CURLOPT_FOLLOWLOCATION    => false,
+                CURLOPT_POSTFIELDS        => $payload,
+                CURLOPT_TIMEOUT_MS        => (int)($timeout * 1000),
+                CURLOPT_HTTPHEADER        => [
+                    'Content-Type: application/json',
+                ],
+            ];
+
+        $curl = curl_init();
+        curl_setopt_array($curl, $options);
+
+        $response  = curl_exec($curl);
+        $http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $error     = curl_error($curl);
+        curl_close($curl);
+
+        if (false === $response) {
+            throw new Exception(sprintf(
+                'Unable to connect to %s, reason: %s',
+                $uri,
+                $error
+            ));
+        }
+
+        if ($http_code !== self::HTTP_OK && $http_code !== self::HTTP_NO_CONTENT) {
+            throw new Exception(sprintf(
+                'Unable to connect to %s, reason: %s',
+                $uri,
+                sprintf("Invalid status code: %d", $http_code)
+            ));
+        }
+
+        return $response;
+    }
+}

--- a/src/trifs/jsonrpc/Client/Transporter/DefaultTransporter.php
+++ b/src/trifs/jsonrpc/Client/Transporter/DefaultTransporter.php
@@ -1,0 +1,45 @@
+<?php
+namespace trifs\jsonrpc\Client\Transporter;
+
+class DefaultTransporter implements TransporterInterface
+{
+    /**
+     * Transports payload to uri using file_get_contents().
+     *
+     * @param  string $uri
+     * @param  string $payload
+     * @param  array  $params
+     * @return string $response
+     * @throws Exception if request is invalid
+     */
+    public function request($uri, $payload, array $params)
+    {
+        // set timeout in seconds or use default timeout as fallback
+        if (!isset($params['timeout'])) {
+            throw new Execption("Missing 'timeout' param");
+        }
+
+        $options = [
+            'http' => [
+                'method'        => 'POST',
+                'header'        => 'Content-Type: application/json',
+                'content'       => $payload,
+                'max_redirects' => 0,
+                'timeout'       => (float) $params['timeout'],
+            ],
+        ];
+
+
+        $response = @file_get_contents($uri, false, stream_context_create($options));
+
+        if ($response === false) {
+            throw new Exception(sprintf(
+                'Unable to connect to %s, reason: %s',
+                $uri,
+                error_get_last()['message']
+            ));
+        }
+
+        return $response;
+    }
+}

--- a/src/trifs/jsonrpc/Client/Transporter/Exception.php
+++ b/src/trifs/jsonrpc/Client/Transporter/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace trifs\jsonrpc\Client\Transporter;
+
+class Exception extends \Exception
+{
+}

--- a/src/trifs/jsonrpc/Client/Transporter/TransporterInterface.php
+++ b/src/trifs/jsonrpc/Client/Transporter/TransporterInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace trifs\jsonrpc\Client\Transporter;
+
+interface TransporterInterface
+{
+    /**
+     * Transports payload to uri.
+     *
+     * @param  string $uri
+     * @param  string $payload
+     * @param  array  $params
+     * @return string $response
+     * @throws Exception if request is invalid
+     */
+    public function request($uri, $payload, array $params);
+}


### PR DESCRIPTION
`curl` http transport was added to avoid `file_get_contents` function which does not work on remote URLs when `allow_url_fopen` in php.ini is disabled.